### PR TITLE
2 market rep and maintainers

### DIFF
--- a/src/LaborMarket/LaborMarket.sol
+++ b/src/LaborMarket/LaborMarket.sol
@@ -290,7 +290,7 @@ contract LaborMarket is
         uint256 requestId,
         uint256 submissionId,
         uint256 score
-    ) external onlyMaintainer {
+    ) external {
         require(
             requestId <= serviceRequestId,
             "LaborMarket::review: Request does not exist."

--- a/src/Network/interfaces/LaborMarketNetworkInterface.sol
+++ b/src/Network/interfaces/LaborMarketNetworkInterface.sol
@@ -15,115 +15,76 @@ interface LaborMarketNetworkInterface {
         uint256 baseMaintainerThreshold;
         uint256 baseProviderThreshold;
     }
-    
+
     struct BalanceInfo {
         uint256 locked;
         uint256 lastDecayEpoch;
         uint256 frozenUntilEpoch;
     }
 
-    function setCapacityImplementation(
-        address _capacityImplementation
-    )
+    function setCapacityImplementation(address _capacityImplementation)
         external;
-
 
     function freezeReputation(
-          address _reputationToken
-        , uint256 _reputationTokenId
-        , uint256 _frozenUntilEpoch
-    ) 
-        external;
+        address _reputationToken,
+        uint256 _reputationTokenId,
+        uint256 _frozenUntilEpoch
+    ) external;
 
     function lockReputation(
-          address _account
-        , address _reputationImplementation
-        , uint256 _reputationTokenId
-        , uint256 _amount
-    ) 
-        external;
+        address _account,
+        address _reputationImplementation,
+        uint256 _reputationTokenId,
+        uint256 _amount
+    ) external;
+
+    function unlockReputation(
+        address _account,
+        address _reputationImplementation,
+        uint256 _reputationTokenId,
+        uint256 _amount
+    ) external;
 
     function getAvailableReputation(
-          address _account
-        , address _reputationToken
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
+        address _account,
+        address _reputationToken,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 
     function getReputationManager(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            address
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (address);
 
     function getPendingDecay(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-        , uint256 _lastDecayEpoch
-        , uint256 _frozenUntilEpoch
-    )
-        external 
-        view 
-        returns (
-            uint256
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId,
+        uint256 _lastDecayEpoch,
+        uint256 _frozenUntilEpoch
+    ) external view returns (uint256);
 
     function getDecayRate(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 
     function getDecayInterval(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 
     function getBaseSignalStake(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 
     function getBaseMaintainerThreshold(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 
     function getBaseProviderThreshold(
-          address _reputationImplementation
-        , uint256 _reputationTokenId
-    )
-        external
-        view
-        returns (
-            uint256
-        );
-
+        address _reputationImplementation,
+        uint256 _reputationTokenId
+    ) external view returns (uint256);
 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -346,9 +346,36 @@ contract ContractTest is PRBTest, Cheats {
         // Fulfill the request
         uint256 submissionId = tempMarket.provide(requestId, "IPFS://333");
 
+        assertEq(
+            network.getAvailableReputation(
+                alice,
+                address(repToken),
+                REPUTATION_TOKEN_ID
+            ),
+            100e18
+        );
+
+        // Verify that Alice's reputation is unlocked
+
         changePrank(bob);
+
         // Review the request
         tempMarket.signalReview(requestId);
+
+        // Verify that Maintainers's reputation is locked
+        assertEq(
+            network.getAvailableReputation(
+                bob,
+                address(repToken),
+                REPUTATION_TOKEN_ID
+            ),
+            (1000e18 -
+                network.getBaseSignalStake(
+                    address(repToken),
+                    REPUTATION_TOKEN_ID
+                ))
+        );
+
         tempMarket.review(requestId, submissionId, 2);
 
         // Claim the reward

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -69,15 +69,16 @@ contract ContractTest is PRBTest, Cheats {
         // Deploy a labor market factory
         factory = new LaborMarketFactory(address(implementation));
 
-        LaborMarketNetworkInterface.ReputationTokenConfig 
-            memory repConfig = LaborMarketNetworkInterface.ReputationTokenConfig({
-                manager: deployer,
-                decayRate: 0,
-                decayInterval: 0,
-                baseSignalStake: 1e18,
-                baseMaintainerThreshold: 100e18,
-                baseProviderThreshold: 10e18
-        });
+        LaborMarketNetworkInterface.ReputationTokenConfig
+            memory repConfig = LaborMarketNetworkInterface
+                .ReputationTokenConfig({
+                    manager: deployer,
+                    decayRate: 0,
+                    decayInterval: 0,
+                    baseSignalStake: 1e18,
+                    baseMaintainerThreshold: 100e18,
+                    baseProviderThreshold: 10e18
+                });
 
         // Deploy a labor market network
         network = new LaborMarketNetwork({
@@ -128,7 +129,7 @@ contract ContractTest is PRBTest, Cheats {
         repToken.setApprovalForAll(address(tempMarket), true);
 
         changePrank(bob);
-        repToken.freeMint(bob, REPUTATION_TOKEN_ID, 100e18);
+        repToken.freeMint(bob, REPUTATION_TOKEN_ID, 1000e18);
         repToken.freeMint(bob, DELEGATE_TOKEN_ID, 1);
         repToken.setApprovalForAll(address(tempMarket), true);
 
@@ -167,7 +168,7 @@ contract ContractTest is PRBTest, Cheats {
 
         changePrank(bob);
         // Review the request
-        tempMarket.signalReview(submissionId);
+        tempMarket.signalReview(requestId);
         tempMarket.review(requestId, submissionId, 2);
 
         // Claim the reward
@@ -220,18 +221,17 @@ contract ContractTest is PRBTest, Cheats {
         // Have bob review the submissions
         changePrank(bob);
 
+        tempMarket.signalReview(requestId);
+
         for (uint256 i; i < 113; i++) {
             if (i < 67) {
                 // BAD
-                tempMarket.signalReview(i + 1);
                 tempMarket.review(requestId, i + 1, 0);
             } else if (i < 103) {
                 // OK
-                tempMarket.signalReview(i + 1);
                 tempMarket.review(requestId, i + 1, 1);
             } else {
                 // GOOD
-                tempMarket.signalReview(i + 1);
                 tempMarket.review(requestId, i + 1, 2);
             }
         }
@@ -301,7 +301,7 @@ contract ContractTest is PRBTest, Cheats {
             tempMarket.provide(requestId, "IPFS://333");
 
             changePrank(bob);
-            tempMarket.signalReview(1);
+            tempMarket.signalReview(requestId);
             tempMarket.review(requestId, 1, 2);
 
             changePrank(alice);
@@ -309,5 +309,53 @@ contract ContractTest is PRBTest, Cheats {
             tempMarket.claim(requestId);
         }
         vm.stopPrank();
+    }
+
+    function test_ReputationalChangesBasedOnActions() public {
+        vm.startPrank(bob);
+
+        // Create a request
+        uint256 requestId = tempMarket.submitRequest({
+            pToken: address(repToken),
+            pTokenId: PAYMENT_TOKEN_ID,
+            pTokenQ: 100e18,
+            signalExp: block.timestamp + 1 hours,
+            submissionExp: block.timestamp + 1 days,
+            enforcementExp: block.timestamp + 1 weeks,
+            requestUri: "ipfs://222"
+        });
+
+        // Signal the request
+        changePrank(alice);
+        tempMarket.signal(requestId);
+
+        // Verify that Alice's reputation is locked
+        assertEq(
+            network.getAvailableReputation(
+                alice,
+                address(repToken),
+                REPUTATION_TOKEN_ID
+            ),
+            (100e18 -
+                network.getBaseSignalStake(
+                    address(repToken),
+                    REPUTATION_TOKEN_ID
+                ))
+        );
+
+        // Fulfill the request
+        uint256 submissionId = tempMarket.provide(requestId, "IPFS://333");
+
+        changePrank(bob);
+        // Review the request
+        tempMarket.signalReview(requestId);
+        tempMarket.review(requestId, submissionId, 2);
+
+        // Claim the reward
+        changePrank(alice);
+
+        // Skip to enforcement deadline
+        vm.warp(5 weeks);
+        tempMarket.claim(submissionId);
     }
 }


### PR DESCRIPTION
- Maintainers now signal requestId instead of submission Ids
- Some actions will lock/unlock reputation at the network lever. However, there is a few things to review in general logistics that disallow completion of the entire model (will discuss in meeting)